### PR TITLE
Depend upon the new version of `Colors`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,8 +10,5 @@ IntervalSets = "8197267c-284f-5f27-9208-e0e47529a953"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [compat]
+Colors = "0.13"
 GLMakie = "0.13"
-
-[sources]
-Colors = {url = "https://github.com/Sagnac/Colors.jl", rev = "master"}
-IntervalSets = {url = "https://github.com/Sagnac/IntervalSets.jl", rev = "range"}

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 <img src="./images/complex_plot.png" width="556">
 
-`complex_color(s, color = HSL)` converts an array of complex numbers into an image matrix of RGB values using a hue-lightness color mapping for the phase and modulus.
+`complex_color(s, color = Oklch)` converts an array of complex numbers into an image matrix of RGB values using a hue-lightness color mapping for the phase and modulus.
 
-`complex_plot(x, y, s, color = HSL)` plots a complex number array `s` within the `x` and `y` limits using domain coloring in the HSL or perceptual OKLCH color spaces.
+`complex_plot(x, y, s, color = Oklch)` plots a complex number array `s` within the `x` and `y` limits using domain coloring in the HSL or perceptual OKLCH color spaces.
 
 ***Note***: The phase contour lines are kinda bugged at the moment at around `±π`; these contours are not displayed by default, but can be toggled on the plot.
 
@@ -13,11 +13,6 @@
 ```julia
 using Pkg
 Pkg.add(url="https://github.com/Sagnac/ComplexColor.jl")
-```
-
-Support for the Oklch color space requires the following fork:
-```julia
-Pkg.add(url="https://github.com/Sagnac/Colors.jl")
 ```
 
 ## Plotting examples

--- a/src/ComplexColor.jl
+++ b/src/ComplexColor.jl
@@ -25,11 +25,7 @@ const n = 500
 const modulus_levels = exp2.(-7:15)
 const modulus_colormap = Reverse(:acton)
 
-const colors_compat = pkgversion(Colors) <= v"0.12.11"
-
-const default = colors_compat ? HSL : Oklch
-
-__init__() = colors_compat && @warn "Oklch color is not available in this version."
+const default = Oklch
 
 @kwdef struct Coordinates
     x::Vector{Float64}
@@ -322,11 +318,8 @@ function clamp01nan1!(img::AbstractArray{<:Colorant})
 end
 
 const colormaps = Dict{Spaces, Vector{RGB{Float64}}}(
-    HSL => map(RGB, HSL(i, 1.0, 0.5) for i = range(-60, 300, 2^10)),
+    HSL   => map(RGB, HSL(i, 1.0, 0.5) for i = range(-60, 300, 2^10)),
+    Oklch => map(RGB, Oklch(0.5, chroma, i) for i = range(-30, 330, 2^10))
 )
-
-if !colors_compat
-    colormaps[Oklch] = map(RGB, Oklch(0.5, chroma, i) for i = range(-30, 330, 2^10))
-end
 
 end


### PR DESCRIPTION
IntervalSets will be left in `sources` for ease of reproducing the environment in case there's a desire to use the other range methods, but they aren't strictly necessary to use the package.

ComplexColor does export OpenInterval and the interval string macro, but these aren't necessary to plot since support for the other half-open and closed intervals is there.

This merge will be pending a Makie release, but their Colors compat has already been bumped in master.